### PR TITLE
docs: Auto-translate README and Wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,36 @@
+
+<div align="right">
+  <details>
+    <summary >🌐 Language</summary>
+    <div>
+      <div align="center">
+        <a href="https://openaitx.github.io/view.html?user=dl-ezo&project=claude-code-sub-agents&lang=en">English</a>
+        | <a href="https://openaitx.github.io/view.html?user=dl-ezo&project=claude-code-sub-agents&lang=zh-CN">简体中文</a>
+        | <a href="https://openaitx.github.io/view.html?user=dl-ezo&project=claude-code-sub-agents&lang=zh-TW">繁體中文</a>
+        | <a href="https://openaitx.github.io/view.html?user=dl-ezo&project=claude-code-sub-agents&lang=ja">日本語</a>
+        | <a href="https://openaitx.github.io/view.html?user=dl-ezo&project=claude-code-sub-agents&lang=ko">한국어</a>
+        | <a href="https://openaitx.github.io/view.html?user=dl-ezo&project=claude-code-sub-agents&lang=hi">हिन्दी</a>
+        | <a href="https://openaitx.github.io/view.html?user=dl-ezo&project=claude-code-sub-agents&lang=th">ไทย</a>
+        | <a href="https://openaitx.github.io/view.html?user=dl-ezo&project=claude-code-sub-agents&lang=fr">Français</a>
+        | <a href="https://openaitx.github.io/view.html?user=dl-ezo&project=claude-code-sub-agents&lang=de">Deutsch</a>
+        | <a href="https://openaitx.github.io/view.html?user=dl-ezo&project=claude-code-sub-agents&lang=es">Español</a>
+        | <a href="https://openaitx.github.io/view.html?user=dl-ezo&project=claude-code-sub-agents&lang=it">Italiano</a>
+        | <a href="https://openaitx.github.io/view.html?user=dl-ezo&project=claude-code-sub-agents&lang=ru">Русский</a>
+        | <a href="https://openaitx.github.io/view.html?user=dl-ezo&project=claude-code-sub-agents&lang=pt">Português</a>
+        | <a href="https://openaitx.github.io/view.html?user=dl-ezo&project=claude-code-sub-agents&lang=nl">Nederlands</a>
+        | <a href="https://openaitx.github.io/view.html?user=dl-ezo&project=claude-code-sub-agents&lang=pl">Polski</a>
+        | <a href="https://openaitx.github.io/view.html?user=dl-ezo&project=claude-code-sub-agents&lang=ar">العربية</a>
+        | <a href="https://openaitx.github.io/view.html?user=dl-ezo&project=claude-code-sub-agents&lang=fa">فارسی</a>
+        | <a href="https://openaitx.github.io/view.html?user=dl-ezo&project=claude-code-sub-agents&lang=tr">Türkçe</a>
+        | <a href="https://openaitx.github.io/view.html?user=dl-ezo&project=claude-code-sub-agents&lang=vi">Tiếng Việt</a>
+        | <a href="https://openaitx.github.io/view.html?user=dl-ezo&project=claude-code-sub-agents&lang=id">Bahasa Indonesia</a>
+        | <a href="https://openaitx.github.io/view.html?user=dl-ezo&project=claude-code-sub-agents&lang=as">অসমীয়া</
+      </div>
+    </div>
+  </details>
+</div>
+
+
 # Claude Code Comprehensive Agent Collection
 
 **Language**: [English](README.md) | [日本語](README_JA.md)


### PR DESCRIPTION
@moriweiji created [issue-54](https://github.com/OpenAiTx/OpenAiTx/issues/54), user would like to add language badges to the README for easier access to translated versions: German, Spanish, French, Japanese, Korean, Portuguese, and Russian 20 languages. System will auto-update translation for README and Wiki when this repository updated, and support multiple languages google/bing SEO search.

Demo links :
- [English](https://openaitx.github.io/view.html?user=dl-ezo&project=claude-code-sub-agents&lang=en)
- [简体中文](https://openaitx.github.io/view.html?user=dl-ezo&project=claude-code-sub-agents&lang=zh-CN)
- [日本語](https://openaitx.github.io/view.html?user=dl-ezo&project=claude-code-sub-agents&lang=ja)
- [한국어](https://openaitx.github.io/view.html?user=dl-ezo&project=claude-code-sub-agents&lang=ko) ..


<img width="1178" height="537" alt="Image" src="https://github.com/user-attachments/assets/7cd54a88-59c1-455f-9c7d-2db7f05b2962" />

If this was not your expection, please close this PR. Thank you! 🙌